### PR TITLE
[chore] update image tag to latest version

### DIFF
--- a/mariadb-ha/README.md
+++ b/mariadb-ha/README.md
@@ -57,7 +57,7 @@ The current variables can be found in `mariadb-ha/variables` section
     mariadb_slave2_database_port: 3308
     mariadb_database_password: "RhgDPXPEnAgxxXYZ"
     mariadb_image_tag:
-      value: "10.10"
+      value: "latest"
       type: string
     mariadb_database_data_volume_path:
       value: <- `${moncc-volume-path}/mariadb`

--- a/mariadb-ha/mariadb.yaml
+++ b/mariadb-ha/mariadb.yaml
@@ -33,7 +33,7 @@ mariadb-common:
   variables:
     image_tag:
       type: string
-      value: <- $mariadb_image_tag default("10.10")
+      value: <- $mariadb_image_tag default("latest")
     database_name:
       type: string
       env: MYSQL_DATABASE

--- a/mariadb-ha/stack.yaml
+++ b/mariadb-ha/stack.yaml
@@ -46,5 +46,5 @@ stack:
       value: RhgDPXPEnAgxxXYZ
       type: string
     mariadb_image_tag:
-      value: '10.10'
+      value: 'latest'
       type: string

--- a/mariadb/mariadb.yaml
+++ b/mariadb/mariadb.yaml
@@ -29,7 +29,7 @@ mariadb-common:
         - <- `${monk-volume-path}/mariadb-conf:/etc/mysql/conf.d`
   variables:
     mariadb-image:
-      value: <- $mariadb-image-tag default("10.10")
+      value: <- $mariadb-image-tag default("latest")
       type: string
     mysql-root-password:
       env: MYSQL_ROOT_PASSWORD


### PR DESCRIPTION
This pull request includes changes to update the MariaDB image tag from version "10.10" to "latest" across multiple configuration files. The most important changes are as follows:

Updates to MariaDB image tag:

* [`mariadb-ha/README.md`](diffhunk://#diff-56cec8b8a79ee4631c82537643df22eacaeb5d62eed94f58bc7a81c09c008d6cL60-R60): Changed the `mariadb_image_tag` value to "latest".
* [`mariadb-ha/mariadb.yaml`](diffhunk://#diff-53f53a6c0370e30f847af10898b091f895e0fdff4d93d9b0c9ca600a7f7e7a9aL36-R36): Updated the `image_tag` default value to "latest".
* [`mariadb-ha/stack.yaml`](diffhunk://#diff-a9b97f6918434d12a568a56257af9be1233786088711af50597d631aef14fb29L49-R49): Modified the `mariadb_image_tag` value to "latest".
* [`mariadb/mariadb.yaml`](diffhunk://#diff-a194159ee75d7261a4dd24a71407750a682eec113955125ea0dd7e965379232eL32-R32): Set the `mariadb-image` default value to "latest".